### PR TITLE
onActive - call *after* idle = false

### DIFF
--- a/src/Idle.js
+++ b/src/Idle.js
@@ -35,8 +35,8 @@ class IdleJs {
 
   resetTimeout (id, settings) {
     if (this.idle) {
-      settings.onActive.call()
       this.idle = false
+      settings.onActive.call()
     }
     clearTimeout(id)
     if (this.settings.keepTracking) {


### PR DESCRIPTION
Every other on* handler gets called after the `.visible` or `.idle` state gets set to the right value.

But with `onActive`, the value was set only *after* the call, fixing.

Closes #6 