### PR TITLE
Remove unused jscs

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -39,8 +39,6 @@ function lint(files) {
     .pipe($.eslint())
     .pipe($.eslint.format())
     .pipe($.eslint.failOnError())
-    //.pipe($.jscs())
-    //.pipe($.jscs.reporter('fail'))
     .on('error', onError);
 }
 
@@ -112,7 +110,7 @@ function coverage(done) {
     });
 }
 
-const watchFiles = ['src/**/*', 'example/**/*', 'package.json', '**/.eslintrc', '.jscsrc'];
+const watchFiles = ['src/**/*', 'example/**/*', 'package.json', '**/.eslintrc'];
 
 // Run the headless unit tests as you make changes.
 function watch() {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "gulp-eslint": "^1.1.1",
     "gulp-filter": "^3.0.0",
     "gulp-istanbul": "^0.10.3",
-    "gulp-jscs": "^3.0.0",
     "gulp-livereload": "^3.8.1",
     "gulp-load-plugins": "^1.1.0",
     "gulp-mocha": "^2.2.0",


### PR DESCRIPTION
There is no `.jscsrc`,
and the jscs tasks are commented out.

*And* npm audit complains about gulp-jscs (among others).

Removing.