### PR TITLE
Implement stop() and reset()

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ idle.start();
 idle.stop();   // stops all tracking
 idle.reset();  // reset visible and idle state to initial values
 idle.start();
+
+// Reset to a specific state
+idle.reset({
+  idle: false,
+  visible: ! document.hidden,
+})
 ```
 
 ## Running examples

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ var idle = new idleJs({
   onShow: function () {}, // callback function to be executed when window become visible
   keepTracking: true, // set it to false of you want to track only once
   startAtIdle: false // set it to true if you want to start in the idle state
-}).start();
+});
+idle.start();
+
+// In case stopping is needed
+idle.stop();   // stops all tracking
+idle.reset();  // reset visible and idle state to initial values
+idle.start();
 ```
 
 ## Running examples

--- a/src/Idle.js
+++ b/src/Idle.js
@@ -31,6 +31,10 @@ class IdleJs {
     this.lastId = null
 
     this.reset()
+
+    this.stopListener = (event) => {
+      this.stop()
+    }
   }
 
   resetTimeout (id, settings, keepTracking = this.settings.keepTracking) {
@@ -55,10 +59,8 @@ class IdleJs {
   }
 
   start () {
-    window.addEventListener('idle:stop', function (event) {
-      bulkRemoveEventListener(window, this.settings.events)
-      this.resetTimeout(this.lastId, this.settings, false)
-    })
+    window.addEventListener('idle:stop', this.stopListener)
+
     this.lastId = this.timeout(this.settings)
     bulkAddEventListener(window, this.settings.events, function (event) {
       this.lastId = this.resetTimeout(this.lastId, this.settings)
@@ -77,6 +79,17 @@ class IdleJs {
           }
         }
       }.bind(this))
+    }
+  }
+
+  stop () {
+    window.removeEventListener('idle:stop', this.stopListener)
+
+    bulkRemoveEventListener(window, this.settings.events)
+    this.lastId = this.resetTimeout(this.lastId, this.settings, false)
+
+    if (this.settings.onShow || this.settings.onHide) {
+      bulkRemoveEventListener(document, this.visibilityEvents)
     }
   }
 

--- a/src/Idle.js
+++ b/src/Idle.js
@@ -42,7 +42,9 @@ class IdleJs {
       settings.onActive.call()
       this.idle = false
     }
-    clearTimeout(id)
+    if (id) {
+      clearTimeout(id)
+    }
     if (keepTracking) {
       return this.timeout(this.settings)
     }

--- a/src/Idle.js
+++ b/src/Idle.js
@@ -27,10 +27,10 @@ class IdleJs {
       recurIdleCall: false
     }
     this.settings = Object.assign({}, this.defaults, options)
-    this.idle = this.settings.startAtIdle
-    this.visible = !this.settings.startAtIdle
     this.visibilityEvents = ['visibilitychange', 'webkitvisibilitychange', 'mozvisibilitychange', 'msvisibilitychange']
     this.lastId = null
+
+    this.reset()
   }
 
   resetTimeout (id, settings) {
@@ -79,6 +79,11 @@ class IdleJs {
         }
       }.bind(this))
     }
+  }
+
+  reset () {
+    this.idle = this.settings.startAtIdle
+    this.visible = !this.settings.startAtIdle
   }
 }
 

--- a/src/Idle.js
+++ b/src/Idle.js
@@ -33,13 +33,13 @@ class IdleJs {
     this.reset()
   }
 
-  resetTimeout (id, settings) {
+  resetTimeout (id, settings, keepTracking = this.settings.keepTracking) {
     if (this.idle) {
       settings.onActive.call()
       this.idle = false
     }
     clearTimeout(id)
-    if (this.settings.keepTracking) {
+    if (keepTracking) {
       return this.timeout(this.settings)
     }
   }
@@ -57,8 +57,7 @@ class IdleJs {
   start () {
     window.addEventListener('idle:stop', function (event) {
       bulkRemoveEventListener(window, this.settings.events)
-      this.settings.keepTracking = false
-      this.resetTimeout(this.lastId, this.settings)
+      this.resetTimeout(this.lastId, this.settings, false)
     })
     this.lastId = this.timeout(this.settings)
     bulkAddEventListener(window, this.settings.events, function (event) {

--- a/src/Idle.js
+++ b/src/Idle.js
@@ -95,9 +95,10 @@ class IdleJs {
     }
   }
 
-  reset () {
-    this.idle = this.settings.startAtIdle
-    this.visible = !this.settings.startAtIdle
+  reset ({idle = this.settings.startAtIdle,
+          visible = !this.settings.startAtIdle}) {
+    this.idle = idle
+    this.visible = visible
   }
 }
 


### PR DESCRIPTION
Fixes #2 

This adds a `stop()` method, that can be used to stop all tracking, remove all event handlers, and do nothing.

To be able to restart, moved the `visible` and `idle` initialization to a separate `reset()` function,
and made it possible to restart to a specific state.
(Because when using `startAtIdle = true`, restarting would mean IdleJs would claim the document is hidden, even though it is not.)

And documented the stop+restart+start combo.

