### PR TITLE
Change idleJs -> IdleJs in README and vanilla example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```js
 // Those are the default values
-var idle = new idleJs({
+var idle = new IdleJs({
   idle: 10000, // idle time in ms
   events: ['mousemove', 'keydown', 'mousedown', 'touchstart'], // events that will trigger the idle resetter
   onIdle: function () {}, // callback function to be executed after idle time

--- a/example/vanilla/index.html
+++ b/example/vanilla/index.html
@@ -23,9 +23,9 @@
   <div id="status">Active!</div>
   <div id="visibility">Visible!</div>
 
-  <script type="text/javascript" src="../dist/Idle.js"></script>
+  <script type="text/javascript" src="../../dist/Idle.js"></script>
   <script type="text/javascript">
-    new idleJs({
+    new IdleJs({
       onIdle: function(){
         document.querySelector('#status').classList.toggle('idle');
         document.querySelector('#status').textContent = 'Idle!';


### PR DESCRIPTION
the global object name is determined by the `babelBoilerplateOptions.mainVarName` option in `package.json`, which changed to `IdleJs` in a77eece.

Updating README and the vanilla example.

Also fixed the relative path in vanilla.

This does not affect users who require/import, only people using the dist file directly.