### PR TITLE
bulk{Add,Remove}EventListener - always pass callback, pass directly to add/remove

### DIFF
--- a/src/Idle.js
+++ b/src/Idle.js
@@ -1,15 +1,13 @@
 'use strict'
 var bulkAddEventListener = function bulkAddEventListener (object, events, callback) {
   events.forEach(function (event) {
-    object.addEventListener(event, function __idle (event) {
-      callback(event)
-    })
+    object.addEventListener(event, callback)
   })
 }
 
-var bulkRemoveEventListener = function bulkRemoveEventListener (object, events) {
+var bulkRemoveEventListener = function bulkRemoveEventListener (object, events, callback) {
   events.forEach(function (event) {
-    object.removeEventListener(event, __idle)
+    object.removeEventListener(event, callback)
   })
 }
 
@@ -34,6 +32,22 @@ class IdleJs {
 
     this.stopListener = (event) => {
       this.stop()
+    }
+    this.idlenessEventsHandler = (event) => {
+      this.lastId = this.resetTimeout(this.lastId, this.settings)
+    }
+    this.visibilityEventsHandler = (event) => {
+      if (document.hidden || document.webkitHidden || document.mozHidden || document.msHidden) {
+        if (this.visible) {
+          this.visible = false
+          this.settings.onHide.call()
+        }
+      } else {
+        if (!this.visible) {
+          this.visible = true
+          this.settings.onShow.call()
+        }
+      }
     }
   }
 
@@ -63,23 +77,11 @@ class IdleJs {
   start () {
     window.addEventListener('idle:stop', this.stopListener)
     this.lastId = this.timeout(this.settings)
-    bulkAddEventListener(window, this.settings.events, function (event) {
-      this.lastId = this.resetTimeout(this.lastId, this.settings)
-    }.bind(this))
+
+    bulkAddEventListener(window, this.settings.events, this.idlenessEventsHandler);
+
     if (this.settings.onShow || this.settings.onHide) {
-      bulkAddEventListener(document, this.visibilityEvents, function (event) {
-        if (document.hidden || document.webkitHidden || document.mozHidden || document.msHidden) {
-          if (this.visible) {
-            this.visible = false
-            this.settings.onHide.call()
-          }
-        } else {
-          if (!this.visible) {
-            this.visible = true
-            this.settings.onShow.call()
-          }
-        }
-      }.bind(this))
+      bulkAddEventListener(document, this.visibilityEvents, this.visibilityEventsHandler);
     }
     return this
   }
@@ -87,11 +89,11 @@ class IdleJs {
   stop () {
     window.removeEventListener('idle:stop', this.stopListener)
 
-    bulkRemoveEventListener(window, this.settings.events)
+    bulkRemoveEventListener(window, this.settings.events, this.idlenessEventsHandler)
     this.lastId = this.resetTimeout(this.lastId, this.settings, false)
 
     if (this.settings.onShow || this.settings.onHide) {
-      bulkRemoveEventListener(document, this.visibilityEvents)
+      bulkRemoveEventListener(document, this.visibilityEvents, this.visibilityEventsHandler)
     }
   }
 


### PR DESCRIPTION
If we want to remove only the specific listener added by idle.js, the callback reference needs to be the same one as the function passed to addEventListener.

Functions created inside a foreach loop will be separate instances, so:

* making sure the callbacks are only instantiated once, in the constructor,
* made sure that `addEventListener` and `removeEventListener` get the same callback instance,
* explicitly passing those instances to `bulkRemoveEventListener`