### PR TITLE
adding whitelist for files, only publishing the defaults (package.jso…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "hugohil <hugo@soixantecircuits.fr> (https://github.com/hugohil)",
     "Martin Hradil <mhradil@redhat.com> (https://github.com/himdel)"
   ],
+  "files": [
+    "/dist"
+  ],
   "dependencies": {
     "@babel/polyfill": "^7.2.5"
   },


### PR DESCRIPTION
…n, changelog, license, readme) and the distributables

Issue num: https://github.com/soixantecircuits/idle-js/issues/20

Upon running: `npm pack && tar -xvzf *.tgz && rm -rf package *.tgz` (shows you what would get packaged when publishing)
This is what you get for the output: 
```
npm info it worked if it ends with ok
npm info using npm@6.4.1
npm info using node@v11.2.0
npm info lifecycle idle-js@1.1.2~prepublish: idle-js@1.1.2
npm info lifecycle idle-js@1.1.2~prepare: idle-js@1.1.2

> idle-js@1.1.2 prepare /Users/jchou2/workspace/idle-js
> gulp build

[14:59:11] Requiring external module @babel/register
[14:59:12] Using gulpfile ~/workspace/idle-js/gulpfile.babel.js
[14:59:12] Starting 'build'...
[14:59:12] Starting 'lint'...
[14:59:12] Starting 'lint-src'...
[14:59:12] Starting 'lint-gulpfile'...
[14:59:12] Finished 'lint-src' after 690 ms
[14:59:12] Finished 'lint-gulpfile' after 705 ms
[14:59:12] Finished 'lint' after 706 ms
[14:59:12] Starting 'clean'...
[14:59:12] Finished 'clean' after 4.25 ms
[14:59:12] Starting 'build'...
[14:59:15] Version: webpack 4.29.2
Built at: 02/12/2019 2:59:15 PM
      Asset      Size  Chunks             Chunk Names
    Idle.js  85.1 KiB       0  [emitted]  main
Idle.js.map   388 KiB       0  [emitted]  main
Entrypoint main = Idle.js Idle.js.map
[14:59:15] Finished 'build' after 2.56 s
[14:59:15] Finished 'build' after 3.28 s
npm info lifecycle idle-js@1.1.2~prepack: idle-js@1.1.2
npm info lifecycle idle-js@1.1.2~postpack: idle-js@1.1.2
npm notice
npm notice 📦  idle-js@1.1.2
npm notice === Tarball Contents ===
npm notice 1.9kB   package.json
npm notice 94B     CHANGELOG.md
npm notice 1.1kB   LICENSE
npm notice 1.4kB   README.md
npm notice 87.2kB  dist/Idle.js
npm notice 397.4kB dist/Idle.js.map
npm notice === Tarball Details ===
npm notice name:          idle-js
npm notice version:       1.1.2
npm notice filename:      idle-js-1.1.2.tgz
npm notice package size:  134.8 kB
npm notice unpacked size: 489.1 kB
npm notice shasum:        748ab673537267b2a44d0a92f5a21fb11fb2e8a9
npm notice integrity:     sha512-X0Za1+PE+Zx4s[...]Vbo3faZqvmHhw==
npm notice total files:   6
npm notice
idle-js-1.1.2.tgz
npm timing npm Completed in 6391ms
npm info ok
x package/package.json
x package/CHANGELOG.md
x package/LICENSE
x package/README.md
x package/dist/Idle.js
x package/dist/Idle.js.map
```