### PR TITLE
Implement .set(options), fix clearing timeouts, throw on unknown options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,11 +70,11 @@ class IdleJs {
 
   timeout (settings) {
     var timer = (this.settings.recurIdleCall) ? {
-      set: setInterval,
-      clear: clearInterval,
+      set: setInterval.bind(window),
+      clear: clearInterval.bind(window),
     } : {
-      set: setTimeout,
-      clear: clearTimeout,
+      set: setTimeout.bind(window),
+      clear: clearTimeout.bind(window),
     };
 
     var id = timer.set(function () {

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,10 @@ class IdleJs {
 
     return this
   }
+
+  set (options) {
+    this.settings = Object.assign(this.settings, options)
+  }
 }
 
 module.exports = IdleJs

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,10 @@ class IdleJs {
       this.stop()
     }
     this.idlenessEventsHandler = (event) => {
+      if (this.idle) {
+        this.idle = false
+        this.settings.onActive.call()
+      }
       this.resetTimeout(this.settings)
     }
     this.visibilityEventsHandler = (event) => {
@@ -54,10 +58,6 @@ class IdleJs {
   }
 
   resetTimeout (settings, keepTracking = this.settings.keepTracking) {
-    if (this.idle) {
-      this.idle = false
-      settings.onActive.call()
-    }
     if (this.clearTimeout) {
       this.clearTimeout()
       this.clearTimeout = null

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ class IdleJs {
       startAtIdle: false, // set it to true if you want to start in the idle state
       recurIdleCall: false
     }
+    this.throwOnBadKey(Object.keys(options), Object.keys(this.defaults))
     this.settings = Object.assign({}, this.defaults, options)
     this.visibilityEvents = ['visibilitychange', 'webkitvisibilitychange', 'mozvisibilitychange', 'msvisibilitychange']
     this.clearTimeout = null
@@ -117,7 +118,16 @@ class IdleJs {
     return this
   }
 
+  throwOnBadKey (keys, goodKeys) {
+    keys.forEach(function (key) {
+      if (! goodKeys.includes(key)) {
+        throw `set: Unknown key ${key}`
+      }
+    })
+  }
+
   set (options) {
+    this.throwOnBadKey(Object.keys(options), Object.keys(this.defaults))
     this.settings = Object.assign(this.settings, options)
   }
 }


### PR DESCRIPTION
Fixes #19 

This adds a `.set(options)` method, which allows the user to change things like timeout after the library was initialized.

Currently, changing all options is supported, with the following caveats:

* setting `idle`, `keepTracking`,  `recurIdleCall` applies on activity (or start),
* setting `on*` applies immediately,
* setting `events` applies on start,
* setting `startAtIdle` applies on start or reset

---

In order to do that, this also

* fixes `lastId` logic when `recurIdleCall` is set (using `clearTimeout` on a value returned by `setInterval` is not guaranteed to work acrross browsers),
* moves `onActive` call out of `resetTimeout`, which means `stop()` won't trigger `onActive` any more
* adds validation for the keys of options provided to `new` or `set`